### PR TITLE
Add LLM-generated decision tree for Unicode to_lower

### DIFF
--- a/gen_to_lower_tree.py
+++ b/gen_to_lower_tree.py
@@ -10,10 +10,8 @@ Usage:
 """
 
 import csv
-import sys
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -148,15 +146,18 @@ def find_patterns(byte_values: list[int], ret_map: dict[int, tuple]) -> list:
     for ret, vals in sorted(by_ret.items(), key=lambda x: x[1][0]):
         vals = sorted(vals)
 
-        # Check if it's a contiguous range (step=1)
-        if len(vals) >= 3 and vals == list(range(vals[0], vals[-1] + 1)):
-            patterns.append(RangeGroup(vals[0], vals[-1], ret))
-            continue
-
-        even_vals = sorted(v for v in vals if v % 2 == 0)
-        odd_vals = sorted(v for v in vals if v % 2 == 1)
-
         handled = set()
+
+        # First, find contiguous sub-ranges (step=1)
+        for lo, hi in find_contiguous_sub_ranges(vals, step=1):
+            count = hi - lo + 1
+            if count >= 3:
+                patterns.append(RangeGroup(lo, hi, ret))
+                handled.update(range(lo, hi + 1))
+
+        remaining = sorted(v for v in vals if v not in handled)
+        even_vals = sorted(v for v in remaining if v % 2 == 0)
+        odd_vals = sorted(v for v in remaining if v % 2 == 1)
 
         # Find contiguous even sub-ranges (step=2)
         for lo, hi in find_contiguous_sub_ranges(even_vals, step=2):
@@ -182,7 +183,7 @@ def find_patterns(byte_values: list[int], ret_map: dict[int, tuple]) -> list:
     return patterns
 
 
-def fmt_ret(ret: tuple, src_len: int) -> str:
+def fmt_ret(ret: tuple) -> str:
     """Format a return tuple as Mojo code using Diff (SIMD[DType.int32, 4])."""
     return f"Diff({', '.join(str(x) for x in ret)})"
 
@@ -258,7 +259,7 @@ def generate_2byte(mappings: list[Mapping]) -> str:
                 conds = [gen_condition(p, "b") for p in ps]
                 combined = " or ".join(f"({c})" for c in conds)
                 lines.append(f"        {p_prefix} {combined}:")
-            lines.append(f"            return {fmt_ret(ret, 2)}")
+            lines.append(f"            return {fmt_ret(ret)}")
 
     lines.append("    return Diff(0, 0, 0, 2)")
     return "\n".join(lines)
@@ -308,12 +309,12 @@ def generate_3byte(mappings: list[Mapping]) -> str:
             if len(patterns) == 1 and patterns[0].lo == patterns[0].hi:
                 p = patterns[0]
                 lines.append(f"        {prefix_b} b == {fb} and c == {p.lo}:")
-                lines.append(f"            return {fmt_ret(p.ret, 3)}")
+                lines.append(f"            return {fmt_ret(p.ret)}")
             elif len(patterns) == 1:
                 p = patterns[0]
                 cond_c = gen_condition(p, "c")
                 lines.append(f"        {prefix_b} b == {fb} and {cond_c}:")
-                lines.append(f"            return {fmt_ret(p.ret, 3)}")
+                lines.append(f"            return {fmt_ret(p.ret)}")
             else:
                 # Check if all patterns have same return tuple
                 all_rets = set(p.ret for p in patterns)
@@ -322,7 +323,7 @@ def generate_3byte(mappings: list[Mapping]) -> str:
                     conds = [gen_condition(p, "c") for p in patterns]
                     combined = " or ".join(f"({c})" for c in conds) if len(conds) > 1 else conds[0]
                     lines.append(f"        {prefix_b} b == {fb} and ({combined}):")
-                    lines.append(f"            return {fmt_ret(ret, 3)}")
+                    lines.append(f"            return {fmt_ret(ret)}")
                 else:
                     lines.append(f"        {prefix_b} b == {fb}:")
                     first_c = True
@@ -331,7 +332,7 @@ def generate_3byte(mappings: list[Mapping]) -> str:
                         first_c = False
                         cond = gen_condition(p, "c")
                         lines.append(f"            {prefix_c} {cond}:")
-                        lines.append(f"                return {fmt_ret(p.ret, 3)}")
+                        lines.append(f"                return {fmt_ret(p.ret)}")
 
     lines.append("    return Diff(0, 0, 0, 3)")
     return "\n".join(lines)
@@ -389,7 +390,7 @@ def generate_4byte(mappings: list[Mapping]) -> str:
                     p = patterns[0]
                     cond_d = gen_condition(p, "d")
                     lines.append(f"        {prefix_b} b == {fb} and c == {fc} and {cond_d}:")
-                    lines.append(f"            return {fmt_ret(p.ret, 4)}")
+                    lines.append(f"            return {fmt_ret(p.ret)}")
                 else:
                     all_rets = set(p.ret for p in patterns)
                     if len(all_rets) == 1:
@@ -397,7 +398,7 @@ def generate_4byte(mappings: list[Mapping]) -> str:
                         conds = [gen_condition(p, "d") for p in patterns]
                         combined = " or ".join(f"({c})" for c in conds) if len(conds) > 1 else conds[0]
                         lines.append(f"        {prefix_b} b == {fb} and c == {fc} and ({combined}):")
-                        lines.append(f"            return {fmt_ret(ret, 4)}")
+                        lines.append(f"            return {fmt_ret(ret)}")
                     else:
                         lines.append(f"        {prefix_b} b == {fb} and c == {fc}:")
                         first_d = True
@@ -406,7 +407,7 @@ def generate_4byte(mappings: list[Mapping]) -> str:
                             first_d = False
                             cond = gen_condition(p, "d")
                             lines.append(f"            {prefix_d} {cond}:")
-                            lines.append(f"                return {fmt_ret(p.ret, 4)}")
+                            lines.append(f"                return {fmt_ret(p.ret)}")
             else:
                 lines.append(f"        {prefix_b} b == {fb}:")
                 first_c = True
@@ -426,7 +427,7 @@ def generate_4byte(mappings: list[Mapping]) -> str:
                         p = patterns[0]
                         cond_d = gen_condition(p, "d")
                         lines.append(f"            {prefix_c} c == {fc} and {cond_d}:")
-                        lines.append(f"                return {fmt_ret(p.ret, 4)}")
+                        lines.append(f"                return {fmt_ret(p.ret)}")
                     else:
                         all_rets = set(p.ret for p in patterns)
                         if len(all_rets) == 1:
@@ -434,7 +435,7 @@ def generate_4byte(mappings: list[Mapping]) -> str:
                             conds = [gen_condition(p, "d") for p in patterns]
                             combined = " or ".join(f"({c})" for c in conds) if len(conds) > 1 else conds[0]
                             lines.append(f"            {prefix_c} c == {fc} and ({combined}):")
-                            lines.append(f"                return {fmt_ret(ret, 4)}")
+                            lines.append(f"                return {fmt_ret(ret)}")
                         else:
                             lines.append(f"            {prefix_c} c == {fc}:")
                             first_d = True
@@ -443,7 +444,7 @@ def generate_4byte(mappings: list[Mapping]) -> str:
                                 first_d = False
                                 cond = gen_condition(p, "d")
                                 lines.append(f"                {prefix_d} {cond}:")
-                                lines.append(f"                    return {fmt_ret(p.ret, 4)}")
+                                lines.append(f"                    return {fmt_ret(p.ret)}")
 
     lines.append("    return Diff(0, 0, 0, 0)")
     return "\n".join(lines)
@@ -480,27 +481,33 @@ fn lower_utf8(s: String) -> String:
         if char_length == 1:
             buf.append(Byte(b0 + _to_lower(b0)))
         elif char_length == 2:
-            var diff = _to_lower(b0, p[offset + 1])
+            var b1 = p[offset + 1]
+            var diff = _to_lower(b0, b1)
             var out_len = Int(diff[3])
             buf.append(Byte(Int(b0) + Int(diff[0])))
             if out_len >= 2:
-                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+                buf.append(Byte(Int(b1) + Int(diff[1])))
             if out_len >= 3:
                 buf.append(Byte(Int(diff[2])))
         elif char_length == 3:
-            var diff = _to_lower(b0, p[offset + 1], p[offset + 2])
+            var b1 = p[offset + 1]
+            var b2 = p[offset + 2]
+            var diff = _to_lower(b0, b1, b2)
             var out_len = Int(diff[3])
             buf.append(Byte(Int(b0) + Int(diff[0])))
             if out_len >= 2:
-                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+                buf.append(Byte(Int(b1) + Int(diff[1])))
             if out_len >= 3:
-                buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
+                buf.append(Byte(Int(b2) + Int(diff[2])))
         elif char_length == 4:
-            var diff = _to_lower(b0, p[offset + 1], p[offset + 2], p[offset + 3])
+            var b1 = p[offset + 1]
+            var b2 = p[offset + 2]
+            var b3 = p[offset + 3]
+            var diff = _to_lower(b0, b1, b2, b3)
             buf.append(Byte(Int(b0) + Int(diff[0])))
-            buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
-            buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
-            buf.append(Byte(Int(p[offset + 3]) + Int(diff[3])))
+            buf.append(Byte(Int(b1) + Int(diff[1])))
+            buf.append(Byte(Int(b2) + Int(diff[2])))
+            buf.append(Byte(Int(b3) + Int(diff[3])))
         offset += char_length
 
     return String(unsafe_from_utf8=buf)'''
@@ -511,8 +518,6 @@ def main():
     mappings = parse_csv(csv_file)
     by_len = group_by_src_len(mappings)
 
-    print("from std.bit import count_leading_zeros")
-    print()
     print()
     print("comptime Diff = SIMD[DType.int32, 4]")
     print()

--- a/gen_to_lower_tree.py
+++ b/gen_to_lower_tree.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Generate a Mojo decision-tree to_lower implementation from to_lower.csv.
+
+This script reads the CSV file with Unicode uppercase-to-lowercase mappings
+and generates optimized Mojo code that performs lowercasing by computing
+byte-level adjustments on raw UTF-8 bytes, with no lookup tables.
+
+Usage:
+    python3 gen_to_lower_tree.py > to_lower_v2.mojo
+"""
+
+import csv
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Mapping:
+    src_hex: str
+    src_bytes: list[int]
+    dst_bytes: list[int]
+    diff_bytes: list[int]
+    src_len: int
+    dst_len: int
+
+
+def parse_csv(filename: str) -> list[Mapping]:
+    mappings = []
+    with open(filename) as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header
+        for row in reader:
+            src_bytes = list(map(int, row[4].split()))
+            dst_bytes = list(map(int, row[9].split()))
+            diff_bytes = list(map(int, row[11].split()))
+            mappings.append(Mapping(
+                src_hex=row[0],
+                src_bytes=src_bytes,
+                dst_bytes=dst_bytes,
+                diff_bytes=diff_bytes,
+                src_len=int(row[3]),
+                dst_len=int(row[8]),
+            ))
+    return mappings
+
+
+def group_by_src_len(mappings: list[Mapping]) -> dict[int, list[Mapping]]:
+    groups = defaultdict(list)
+    for m in mappings:
+        groups[m.src_len].append(m)
+    return dict(groups)
+
+
+def compute_return_tuple(m: Mapping, src_len: int) -> tuple:
+    """Compute the (d0, d1, d2, d3) return tuple for a mapping.
+
+    For 2-byte chars: (delta_byte0, delta_byte1, extra_byte_or_0, output_len)
+    For 3-byte chars: (delta_byte0, delta_byte1, delta_byte2, output_len)
+    For 4-byte chars: (delta_byte0, delta_byte1, delta_byte2, delta_byte3)
+      where delta_byte3 for 4-byte is folded into the value directly
+    """
+    if src_len == 1:
+        return (32,)  # always +32 for ASCII
+
+    if src_len == 2:
+        d0 = m.dst_bytes[0] - m.src_bytes[0] if m.dst_len >= 1 else -m.src_bytes[0]
+        d1 = m.dst_bytes[1] - m.src_bytes[1] if m.dst_len >= 2 else -m.src_bytes[1]
+        if m.dst_len == 1:
+            # 2-byte -> 1-byte: output is just dst_bytes[0]
+            # result[0] = src[0] + d0 = dst[0], result[1] = src[1] + d1 = 0
+            return (d0, d1, 0, 1)
+        elif m.dst_len == 3:
+            # 2-byte -> 3-byte
+            return (d0, d1, m.dst_bytes[2], 3)
+        else:
+            return (d0, d1, 0, 2)
+
+    if src_len == 3:
+        if m.dst_len == 1:
+            d0 = m.dst_bytes[0] - m.src_bytes[0]
+            d1 = -m.src_bytes[1]
+            d2 = -m.src_bytes[2]
+            return (d0, d1, d2, 1)
+        elif m.dst_len == 2:
+            d0 = m.dst_bytes[0] - m.src_bytes[0]
+            d1 = m.dst_bytes[1] - m.src_bytes[1]
+            d2 = -m.src_bytes[2]
+            return (d0, d1, d2, 2)
+        else:
+            d0 = m.dst_bytes[0] - m.src_bytes[0]
+            d1 = m.dst_bytes[1] - m.src_bytes[1]
+            d2 = m.dst_bytes[2] - m.src_bytes[2]
+            return (d0, d1, d2, 3)
+
+    if src_len == 4:
+        d0 = m.dst_bytes[0] - m.src_bytes[0]
+        d1 = m.dst_bytes[1] - m.src_bytes[1]
+        d2 = m.dst_bytes[2] - m.src_bytes[2]
+        d3 = m.dst_bytes[3] - m.src_bytes[3]
+        return (d0, d1, d2, d3)
+
+    raise ValueError(f"Unsupported src_len: {src_len}")
+
+
+@dataclass
+class RangeGroup:
+    """A contiguous range of byte values with the same return tuple."""
+    lo: int
+    hi: int
+    ret: tuple
+    even_only: bool = False
+    odd_only: bool = False
+
+
+def find_contiguous_sub_ranges(vals: list[int], step: int = 1) -> list[tuple[int, int]]:
+    """Split sorted values into contiguous sub-ranges with given step."""
+    if not vals:
+        return []
+    ranges = []
+    start = vals[0]
+    prev = vals[0]
+    for v in vals[1:]:
+        if v == prev + step:
+            prev = v
+        else:
+            ranges.append((start, prev))
+            start = v
+            prev = v
+    ranges.append((start, prev))
+    return ranges
+
+
+def find_patterns(byte_values: list[int], ret_map: dict[int, tuple]) -> list:
+    """Find patterns in a set of (byte_value -> return_tuple) mappings.
+    Returns a list of RangeGroup for code generation.
+    """
+    if not byte_values:
+        return []
+
+    # Group consecutive values with the same return tuple
+    by_ret = defaultdict(list)
+    for bv in sorted(byte_values):
+        by_ret[ret_map[bv]].append(bv)
+
+    patterns = []
+    for ret, vals in sorted(by_ret.items(), key=lambda x: x[1][0]):
+        vals = sorted(vals)
+
+        # Check if it's a contiguous range (step=1)
+        if len(vals) >= 3 and vals == list(range(vals[0], vals[-1] + 1)):
+            patterns.append(RangeGroup(vals[0], vals[-1], ret))
+            continue
+
+        even_vals = sorted(v for v in vals if v % 2 == 0)
+        odd_vals = sorted(v for v in vals if v % 2 == 1)
+
+        handled = set()
+
+        # Find contiguous even sub-ranges (step=2)
+        for lo, hi in find_contiguous_sub_ranges(even_vals, step=2):
+            count = (hi - lo) // 2 + 1
+            if count >= 3:
+                patterns.append(RangeGroup(lo, hi, ret, even_only=True))
+                handled.update(range(lo, hi + 1, 2))
+
+        # Find contiguous odd sub-ranges (step=2)
+        for lo, hi in find_contiguous_sub_ranges(odd_vals, step=2):
+            count = (hi - lo) // 2 + 1
+            if count >= 3:
+                patterns.append(RangeGroup(lo, hi, ret, odd_only=True))
+                handled.update(range(lo, hi + 1, 2))
+
+        # Remaining individual values
+        for v in vals:
+            if v not in handled:
+                patterns.append(RangeGroup(v, v, ret))
+
+    # Sort by lo value
+    patterns.sort(key=lambda p: p.lo)
+    return patterns
+
+
+def fmt_ret(ret: tuple, src_len: int) -> str:
+    """Format a return tuple as Mojo code using Diff (SIMD[DType.int32, 4])."""
+    return f"Diff({', '.join(str(x) for x in ret)})"
+
+
+def gen_condition(p: RangeGroup, var_name: str) -> str:
+    """Generate condition expression for a pattern."""
+    if p.lo == p.hi:
+        base = f"{var_name} == {p.lo}"
+    else:
+        base = f"{var_name} >= {p.lo} and {var_name} <= {p.hi}"
+
+    if p.even_only:
+        if p.lo == p.hi:
+            return base
+        return f"{base} and {var_name} & 1 == 0"
+    elif p.odd_only:
+        if p.lo == p.hi:
+            return base
+        return f"{base} and {var_name} & 1 == 1"
+    return base
+
+
+def generate_2byte(mappings: list[Mapping]) -> str:
+    """Generate the 2-byte _to_lower function."""
+    lines = []
+    lines.append("@always_inline")
+    lines.append("fn _to_lower(a: UInt8, b: UInt8) -> Diff:")
+    lines.append('    """Given two bytes of a UTF-8 char, returns byte adjustments for lowercasing.')
+    lines.append("    Returns Diff(delta_byte0, delta_byte1, extra_byte, output_len).")
+    lines.append('    """')
+
+    # Group by first byte
+    by_first = defaultdict(list)
+    for m in mappings:
+        by_first[m.src_bytes[0]].append(m)
+
+    first = True
+    for fb in sorted(by_first.keys()):
+        group = by_first[fb]
+        prefix = "if" if first else "elif"
+        first = False
+
+        lines.append(f"    {prefix} a == {fb}:")
+
+        # Build a map from second byte to return tuple
+        ret_map = {}
+        for m in group:
+            ret = compute_return_tuple(m, 2)
+            ret_map[m.src_bytes[1]] = ret
+
+        patterns = find_patterns(list(ret_map.keys()), ret_map)
+
+        # Group patterns by return value to merge conditions
+        by_ret_ordered = []
+        seen_rets = {}
+        for p in patterns:
+            if p.ret not in seen_rets:
+                seen_rets[p.ret] = len(by_ret_ordered)
+                by_ret_ordered.append((p.ret, [p]))
+            else:
+                by_ret_ordered[seen_rets[p.ret]][1].append(p)
+
+        emitted_first = True
+        for ret, ps in by_ret_ordered:
+            p_prefix = "if" if emitted_first else "elif"
+            emitted_first = False
+            if len(ps) == 1 and ps[0].lo == ps[0].hi:
+                lines.append(f"        {p_prefix} b == {ps[0].lo}:")
+            elif len(ps) == 1:
+                cond = gen_condition(ps[0], "b")
+                lines.append(f"        {p_prefix} {cond}:")
+            else:
+                conds = [gen_condition(p, "b") for p in ps]
+                combined = " or ".join(f"({c})" for c in conds)
+                lines.append(f"        {p_prefix} {combined}:")
+            lines.append(f"            return {fmt_ret(ret, 2)}")
+
+    lines.append("    return Diff(0, 0, 0, 2)")
+    return "\n".join(lines)
+
+
+def generate_3byte(mappings: list[Mapping]) -> str:
+    """Generate the 3-byte _to_lower function."""
+    lines = []
+    lines.append("@always_inline")
+    lines.append("fn _to_lower(a: UInt8, b: UInt8, c: UInt8) -> Diff:")
+    lines.append('    """Given three bytes of a UTF-8 char, returns byte adjustments for lowercasing.')
+    lines.append("    Returns Diff(delta_byte0, delta_byte1, delta_byte2, output_len).")
+    lines.append('    """')
+
+    # Group by first byte
+    by_first = defaultdict(list)
+    for m in mappings:
+        by_first[m.src_bytes[0]].append(m)
+
+    first_a = True
+    for fa in sorted(by_first.keys()):
+        group_a = by_first[fa]
+        prefix_a = "if" if first_a else "elif"
+        first_a = False
+        lines.append(f"    {prefix_a} a == {fa}:")
+
+        # Group by second byte
+        by_second = defaultdict(list)
+        for m in group_a:
+            by_second[m.src_bytes[1]].append(m)
+
+        first_b = True
+        for fb in sorted(by_second.keys()):
+            group_b = by_second[fb]
+            prefix_b = "if" if first_b else "elif"
+            first_b = False
+
+            # Build ret_map for third byte
+            ret_map = {}
+            for m in group_b:
+                ret = compute_return_tuple(m, 3)
+                ret_map[m.src_bytes[2]] = ret
+
+            patterns = find_patterns(list(ret_map.keys()), ret_map)
+
+            # If only one pattern/value
+            if len(patterns) == 1 and patterns[0].lo == patterns[0].hi:
+                p = patterns[0]
+                lines.append(f"        {prefix_b} b == {fb} and c == {p.lo}:")
+                lines.append(f"            return {fmt_ret(p.ret, 3)}")
+            elif len(patterns) == 1:
+                p = patterns[0]
+                cond_c = gen_condition(p, "c")
+                lines.append(f"        {prefix_b} b == {fb} and {cond_c}:")
+                lines.append(f"            return {fmt_ret(p.ret, 3)}")
+            else:
+                # Check if all patterns have same return tuple
+                all_rets = set(p.ret for p in patterns)
+                if len(all_rets) == 1:
+                    ret = patterns[0].ret
+                    conds = [gen_condition(p, "c") for p in patterns]
+                    combined = " or ".join(f"({c})" for c in conds) if len(conds) > 1 else conds[0]
+                    lines.append(f"        {prefix_b} b == {fb} and ({combined}):")
+                    lines.append(f"            return {fmt_ret(ret, 3)}")
+                else:
+                    lines.append(f"        {prefix_b} b == {fb}:")
+                    first_c = True
+                    for p in patterns:
+                        prefix_c = "if" if first_c else "elif"
+                        first_c = False
+                        cond = gen_condition(p, "c")
+                        lines.append(f"            {prefix_c} {cond}:")
+                        lines.append(f"                return {fmt_ret(p.ret, 3)}")
+
+    lines.append("    return Diff(0, 0, 0, 3)")
+    return "\n".join(lines)
+
+
+def generate_4byte(mappings: list[Mapping]) -> str:
+    """Generate the 4-byte _to_lower function."""
+    lines = []
+    lines.append("@always_inline")
+    lines.append("fn _to_lower(a: UInt8, b: UInt8, c: UInt8, d: UInt8) -> Diff:")
+    lines.append('    """Given four bytes of a UTF-8 char, returns byte adjustments for lowercasing.')
+    lines.append("    Returns Diff(delta_byte0, delta_byte1, delta_byte2, delta_byte3).")
+    lines.append('    """')
+
+    # Group by first byte
+    by_first = defaultdict(list)
+    for m in mappings:
+        by_first[m.src_bytes[0]].append(m)
+
+    first_a = True
+    for fa in sorted(by_first.keys()):
+        group_a = by_first[fa]
+        prefix_a = "if" if first_a else "elif"
+        first_a = False
+        lines.append(f"    {prefix_a} a == {fa}:")
+
+        # Group by second byte
+        by_second = defaultdict(list)
+        for m in group_a:
+            by_second[m.src_bytes[1]].append(m)
+
+        first_b = True
+        for fb in sorted(by_second.keys()):
+            group_b = by_second[fb]
+            prefix_b = "if" if first_b else "elif"
+            first_b = False
+
+            # Group by third byte
+            by_third = defaultdict(list)
+            for m in group_b:
+                by_third[m.src_bytes[2]].append(m)
+
+            if len(by_third) == 1:
+                fc = list(by_third.keys())[0]
+                group_c = by_third[fc]
+
+                ret_map = {}
+                for m in group_c:
+                    ret = compute_return_tuple(m, 4)
+                    ret_map[m.src_bytes[3]] = ret
+
+                patterns = find_patterns(list(ret_map.keys()), ret_map)
+
+                if len(patterns) == 1:
+                    p = patterns[0]
+                    cond_d = gen_condition(p, "d")
+                    lines.append(f"        {prefix_b} b == {fb} and c == {fc} and {cond_d}:")
+                    lines.append(f"            return {fmt_ret(p.ret, 4)}")
+                else:
+                    all_rets = set(p.ret for p in patterns)
+                    if len(all_rets) == 1:
+                        ret = patterns[0].ret
+                        conds = [gen_condition(p, "d") for p in patterns]
+                        combined = " or ".join(f"({c})" for c in conds) if len(conds) > 1 else conds[0]
+                        lines.append(f"        {prefix_b} b == {fb} and c == {fc} and ({combined}):")
+                        lines.append(f"            return {fmt_ret(ret, 4)}")
+                    else:
+                        lines.append(f"        {prefix_b} b == {fb} and c == {fc}:")
+                        first_d = True
+                        for p in patterns:
+                            prefix_d = "if" if first_d else "elif"
+                            first_d = False
+                            cond = gen_condition(p, "d")
+                            lines.append(f"            {prefix_d} {cond}:")
+                            lines.append(f"                return {fmt_ret(p.ret, 4)}")
+            else:
+                lines.append(f"        {prefix_b} b == {fb}:")
+                first_c = True
+                for fc in sorted(by_third.keys()):
+                    group_c = by_third[fc]
+                    prefix_c = "if" if first_c else "elif"
+                    first_c = False
+
+                    ret_map = {}
+                    for m in group_c:
+                        ret = compute_return_tuple(m, 4)
+                        ret_map[m.src_bytes[3]] = ret
+
+                    patterns = find_patterns(list(ret_map.keys()), ret_map)
+
+                    if len(patterns) == 1:
+                        p = patterns[0]
+                        cond_d = gen_condition(p, "d")
+                        lines.append(f"            {prefix_c} c == {fc} and {cond_d}:")
+                        lines.append(f"                return {fmt_ret(p.ret, 4)}")
+                    else:
+                        all_rets = set(p.ret for p in patterns)
+                        if len(all_rets) == 1:
+                            ret = patterns[0].ret
+                            conds = [gen_condition(p, "d") for p in patterns]
+                            combined = " or ".join(f"({c})" for c in conds) if len(conds) > 1 else conds[0]
+                            lines.append(f"            {prefix_c} c == {fc} and ({combined}):")
+                            lines.append(f"                return {fmt_ret(ret, 4)}")
+                        else:
+                            lines.append(f"            {prefix_c} c == {fc}:")
+                            first_d = True
+                            for p in patterns:
+                                prefix_d = "if" if first_d else "elif"
+                                first_d = False
+                                cond = gen_condition(p, "d")
+                                lines.append(f"                {prefix_d} {cond}:")
+                                lines.append(f"                    return {fmt_ret(p.ret, 4)}")
+
+    lines.append("    return Diff(0, 0, 0, 0)")
+    return "\n".join(lines)
+
+
+def generate_main_function() -> str:
+    return '''
+fn lower_utf8(s: String) -> String:
+    """Convert a UTF-8 encoded string to lowercase using a decision tree.
+
+    Args:
+        s: Input string.
+
+    Returns:
+        A new string with all characters converted to lowercase.
+    """
+    var byte_len = s.byte_length()
+    var buf = List[Byte](capacity=byte_len // 2 * 3 + 1)
+    var offset = 0
+    var p = s.unsafe_ptr()
+    while offset < byte_len:
+        var b0 = p[offset]
+        # Detect UTF-8 character length from leading byte
+        var char_length: Int
+        if b0 >> 7 == 0:
+            char_length = 1
+        elif b0 >> 5 == 0b110:
+            char_length = 2
+        elif b0 >> 4 == 0b1110:
+            char_length = 3
+        else:
+            char_length = 4
+
+        if char_length == 1:
+            buf.append(Byte(b0 + _to_lower(b0)))
+        elif char_length == 2:
+            var diff = _to_lower(b0, p[offset + 1])
+            var out_len = Int(diff[3])
+            buf.append(Byte(Int(b0) + Int(diff[0])))
+            if out_len >= 2:
+                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+            if out_len >= 3:
+                buf.append(Byte(Int(diff[2])))
+        elif char_length == 3:
+            var diff = _to_lower(b0, p[offset + 1], p[offset + 2])
+            var out_len = Int(diff[3])
+            buf.append(Byte(Int(b0) + Int(diff[0])))
+            if out_len >= 2:
+                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+            if out_len >= 3:
+                buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
+        elif char_length == 4:
+            var diff = _to_lower(b0, p[offset + 1], p[offset + 2], p[offset + 3])
+            buf.append(Byte(Int(b0) + Int(diff[0])))
+            buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+            buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
+            buf.append(Byte(Int(p[offset + 3]) + Int(diff[3])))
+        offset += char_length
+
+    return String(unsafe_from_utf8=buf)'''
+
+
+def main():
+    csv_file = "to_lower.csv"
+    mappings = parse_csv(csv_file)
+    by_len = group_by_src_len(mappings)
+
+    print("from std.bit import count_leading_zeros")
+    print()
+    print()
+    print("comptime Diff = SIMD[DType.int32, 4]")
+    print()
+    print()
+    # 1-byte: trivial
+    print("@always_inline")
+    print("fn _to_lower(a: UInt8) -> UInt8:")
+    print('    """Branch-free ASCII lowercase. Returns delta to add to the byte."""')
+    print("    var is_upper = (a >= 65) & (a <= 90)")
+    print("    return UInt8(Int(is_upper) * 32)")
+    print()
+    print()
+
+    # 2-byte
+    print(generate_2byte(by_len.get(2, [])))
+    print()
+    print()
+
+    # 3-byte
+    print(generate_3byte(by_len.get(3, [])))
+    print()
+    print()
+
+    # 4-byte
+    print(generate_4byte(by_len.get(4, [])))
+    print()
+
+    # Main function
+    print(generate_main_function())
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/test_to_lower_v2.mojo
+++ b/test_to_lower_v2.mojo
@@ -3,38 +3,12 @@
 from to_lower_v2 import lower_utf8, _to_lower, Diff
 
 
-def parse_int(s: String) raises -> Int:
-    return Int(s)
-
-
-def split_csv_line(line: String) -> List[String]:
-    """Split a CSV line by commas."""
-    var result = List[String]()
-    var current = String("")
-    for ch in line.codepoint_slices():
-        if ch == ",":
-            result.append(current^)
-            current = String("")
-        else:
-            current += String(ch)
-    if len(current) > 0:
-        result.append(current^)
-    return result^
-
-
 def parse_bytes(s: String) raises -> List[Int]:
     """Parse a space-separated byte string like '195 128' into a list of ints."""
     var result = List[Int]()
-    var current = String("")
-    for ch in s.codepoint_slices():
-        if ch == " ":
-            if len(current) > 0:
-                result.append(Int(current))
-                current = String("")
-        else:
-            current += String(ch)
-    if len(current) > 0:
-        result.append(Int(current))
+    for part in s.split(" "):
+        if len(part) > 0:
+            result.append(Int(String(part)))
     return result^
 
 
@@ -57,15 +31,15 @@ def test_individual_mappings() raises -> Int:
         if len(line) < 5:
             continue
 
-        var fields = split_csv_line(String(line))
+        var fields = String(line).split(",")
         if len(fields) < 12:
             continue
 
-        var src_hex = fields[0]
-        var src_len = Int(fields[3])
-        var src_bytes_str = fields[4]
-        var dst_len = Int(fields[8])
-        var dst_bytes_str = fields[9]
+        var src_hex = String(fields[0])
+        var src_len = Int(String(fields[3]))
+        var src_bytes_str = String(fields[4])
+        var dst_len = Int(String(fields[8]))
+        var dst_bytes_str = String(fields[9])
 
         var src_bytes = parse_bytes(src_bytes_str)
         var dst_bytes = parse_bytes(dst_bytes_str)

--- a/test_to_lower_v2.mojo
+++ b/test_to_lower_v2.mojo
@@ -1,0 +1,285 @@
+"""Test the generated decision tree to_lower against to_lower.csv."""
+
+from to_lower_v2 import lower_utf8, _to_lower, Diff
+
+
+def parse_int(s: String) raises -> Int:
+    return Int(s)
+
+
+def split_csv_line(line: String) -> List[String]:
+    """Split a CSV line by commas."""
+    var result = List[String]()
+    var current = String("")
+    for ch in line.codepoint_slices():
+        if ch == ",":
+            result.append(current^)
+            current = String("")
+        else:
+            current += String(ch)
+    if len(current) > 0:
+        result.append(current^)
+    return result^
+
+
+def parse_bytes(s: String) raises -> List[Int]:
+    """Parse a space-separated byte string like '195 128' into a list of ints."""
+    var result = List[Int]()
+    var current = String("")
+    for ch in s.codepoint_slices():
+        if ch == " ":
+            if len(current) > 0:
+                result.append(Int(current))
+                current = String("")
+        else:
+            current += String(ch)
+    if len(current) > 0:
+        result.append(Int(current))
+    return result^
+
+
+def test_individual_mappings() raises -> Int:
+    """Test each mapping in the CSV individually.
+    Returns the number of failures.
+    """
+    var failures = 0
+    var tested = 0
+
+    var content: String
+    with open("to_lower.csv", "r") as f:
+        content = f.read()
+
+    # Split into lines
+    var lines = content.split("\n")
+
+    for i in range(1, len(lines)):
+        var line = lines[i]
+        if len(line) < 5:
+            continue
+
+        var fields = split_csv_line(String(line))
+        if len(fields) < 12:
+            continue
+
+        var src_hex = fields[0]
+        var src_len = Int(fields[3])
+        var src_bytes_str = fields[4]
+        var dst_len = Int(fields[8])
+        var dst_bytes_str = fields[9]
+
+        var src_bytes = parse_bytes(src_bytes_str)
+        var dst_bytes = parse_bytes(dst_bytes_str)
+
+        tested += 1
+
+        if src_len == 1:
+            var delta = _to_lower(UInt8(src_bytes[0]))
+            var result_byte = Int(UInt8(src_bytes[0]) + delta)
+            if result_byte != dst_bytes[0]:
+                print(
+                    "FAIL 1-byte U+"
+                    + src_hex
+                    + ": got "
+                    + String(result_byte)
+                    + " expected "
+                    + String(dst_bytes[0])
+                )
+                failures += 1
+
+        elif src_len == 2:
+            var diff = _to_lower(UInt8(src_bytes[0]), UInt8(src_bytes[1]))
+            var d0 = Int(diff[0])
+            var d1 = Int(diff[1])
+            var extra = Int(diff[2])
+            var out_len = Int(diff[3])
+
+            var ok = True
+            if out_len != dst_len:
+                ok = False
+            elif out_len == 1:
+                var r0 = (src_bytes[0] + d0) & 0xFF
+                if r0 != dst_bytes[0]:
+                    ok = False
+            elif out_len == 3:
+                var r0 = (src_bytes[0] + d0) & 0xFF
+                var r1 = (src_bytes[1] + d1) & 0xFF
+                var r2 = extra & 0xFF
+                if r0 != dst_bytes[0] or r1 != dst_bytes[1] or r2 != dst_bytes[2]:
+                    ok = False
+            else:  # out_len == 2
+                var r0 = (src_bytes[0] + d0) & 0xFF
+                var r1 = (src_bytes[1] + d1) & 0xFF
+                if r0 != dst_bytes[0] or r1 != dst_bytes[1]:
+                    ok = False
+
+            if not ok:
+                print(
+                    "FAIL 2-byte U+"
+                    + src_hex
+                    + " src="
+                    + src_bytes_str
+                    + " diff=("
+                    + String(d0)
+                    + ","
+                    + String(d1)
+                    + ","
+                    + String(extra)
+                    + ","
+                    + String(out_len)
+                    + ")"
+                    + " expected dst="
+                    + dst_bytes_str
+                )
+                failures += 1
+
+        elif src_len == 3:
+            var diff = _to_lower(
+                UInt8(src_bytes[0]), UInt8(src_bytes[1]), UInt8(src_bytes[2])
+            )
+            var d0 = Int(diff[0])
+            var d1 = Int(diff[1])
+            var d2 = Int(diff[2])
+            var out_len = Int(diff[3])
+
+            var ok = True
+            if out_len != dst_len:
+                ok = False
+            elif out_len == 1:
+                var r0 = (src_bytes[0] + d0) & 0xFF
+                if r0 != dst_bytes[0]:
+                    ok = False
+            elif out_len == 2:
+                var r0 = (src_bytes[0] + d0) & 0xFF
+                var r1 = (src_bytes[1] + d1) & 0xFF
+                if r0 != dst_bytes[0] or r1 != dst_bytes[1]:
+                    ok = False
+            else:  # out_len == 3
+                var r0 = (src_bytes[0] + d0) & 0xFF
+                var r1 = (src_bytes[1] + d1) & 0xFF
+                var r2 = (src_bytes[2] + d2) & 0xFF
+                if r0 != dst_bytes[0] or r1 != dst_bytes[1] or r2 != dst_bytes[2]:
+                    ok = False
+
+            if not ok:
+                print(
+                    "FAIL 3-byte U+"
+                    + src_hex
+                    + " src="
+                    + src_bytes_str
+                    + " diff=("
+                    + String(d0)
+                    + ","
+                    + String(d1)
+                    + ","
+                    + String(d2)
+                    + ","
+                    + String(out_len)
+                    + ")"
+                    + " expected dst="
+                    + dst_bytes_str
+                )
+                failures += 1
+
+        elif src_len == 4:
+            var diff = _to_lower(
+                UInt8(src_bytes[0]),
+                UInt8(src_bytes[1]),
+                UInt8(src_bytes[2]),
+                UInt8(src_bytes[3]),
+            )
+            var d0 = Int(diff[0])
+            var d1 = Int(diff[1])
+            var d2 = Int(diff[2])
+            var d3 = Int(diff[3])
+
+            var r0 = (src_bytes[0] + d0) & 0xFF
+            var r1 = (src_bytes[1] + d1) & 0xFF
+            var r2 = (src_bytes[2] + d2) & 0xFF
+            var r3 = (src_bytes[3] + d3) & 0xFF
+
+            if (
+                r0 != dst_bytes[0]
+                or r1 != dst_bytes[1]
+                or r2 != dst_bytes[2]
+                or r3 != dst_bytes[3]
+            ):
+                print(
+                    "FAIL 4-byte U+"
+                    + src_hex
+                    + " src="
+                    + src_bytes_str
+                    + " diff=("
+                    + String(d0)
+                    + ","
+                    + String(d1)
+                    + ","
+                    + String(d2)
+                    + ","
+                    + String(d3)
+                    + ")"
+                    + " expected dst="
+                    + dst_bytes_str
+                )
+                failures += 1
+
+    print("Tested " + String(tested) + " mappings, " + String(failures) + " failures")
+    return failures
+
+
+def test_lower_utf8_strings() -> Int:
+    """Test lower_utf8 on complete strings."""
+    var failures = 0
+
+    # ASCII test
+    var r1 = lower_utf8(String("HELLO WORLD"))
+    if r1 != "hello world":
+        print("FAIL ASCII: got '" + r1 + "' expected 'hello world'")
+        failures += 1
+
+    # Latin extended
+    var r2 = lower_utf8(String("ÀÁÂÃÄÅÆÇÈÉ"))
+    if r2 != "àáâãäåæçèé":
+        print("FAIL Latin: got '" + r2 + "' expected 'àáâãäåæçèé'")
+        failures += 1
+
+    # Greek
+    var r3 = lower_utf8(String("ΑΒΓΔΕΖΗΘ"))
+    if r3 != "αβγδεζηθ":
+        print("FAIL Greek: got '" + r3 + "' expected 'αβγδεζηθ'")
+        failures += 1
+
+    # Cyrillic
+    var r4 = lower_utf8(String("АБВГДЕЖЗ"))
+    if r4 != "абвгдежз":
+        print("FAIL Cyrillic: got '" + r4 + "' expected 'абвгдежз'")
+        failures += 1
+
+    # Mixed - already lowercase should not change
+    var r5 = lower_utf8(String("already lowercase 123"))
+    if r5 != "already lowercase 123":
+        print("FAIL passthrough: got '" + r5 + "'")
+        failures += 1
+
+    return failures
+
+
+def main() raises:
+    print("=== Testing individual mappings against CSV ===")
+    var mapping_failures = test_individual_mappings()
+    if mapping_failures == 0:
+        print("All individual mapping tests PASSED!")
+
+    print()
+    print("=== Testing lower_utf8 on strings ===")
+    var string_failures = test_lower_utf8_strings()
+    if string_failures == 0:
+        print("All string tests PASSED!")
+    else:
+        print(String(string_failures) + " string tests FAILED")
+
+    print()
+    var total = mapping_failures + string_failures
+    if total == 0:
+        print("ALL TESTS PASSED!")
+    else:
+        print("TOTAL FAILURES: " + String(total))

--- a/to_lower_v2.mojo
+++ b/to_lower_v2.mojo
@@ -1,5 +1,3 @@
-from std.bit import count_leading_zeros
-
 
 comptime Diff = SIMD[DType.int32, 4]
 
@@ -17,7 +15,7 @@ fn _to_lower(a: UInt8, b: UInt8) -> Diff:
     Returns Diff(delta_byte0, delta_byte1, extra_byte, output_len).
     """
     if a == 195:
-        if (b >= 128 and b <= 158 and b & 1 == 0) or (b >= 129 and b <= 149 and b & 1 == 1) or (b >= 153 and b <= 157 and b & 1 == 1):
+        if (b >= 128 and b <= 150) or (b >= 152 and b <= 158):
             return Diff(0, 32, 0, 2)
     elif a == 196:
         if (b >= 128 and b <= 174 and b & 1 == 0) or (b >= 178 and b <= 182 and b & 1 == 0) or (b >= 185 and b <= 189 and b & 1 == 1):
@@ -107,7 +105,7 @@ fn _to_lower(a: UInt8, b: UInt8) -> Diff:
             return Diff(1, -1, 0, 2)
         elif b >= 145 and b <= 159:
             return Diff(0, 32, 0, 2)
-        elif (b == 160) or (b >= 161 and b <= 171 and b & 1 == 1) or (b >= 164 and b <= 170 and b & 1 == 0):
+        elif (b == 160) or (b == 161) or (b >= 163 and b <= 171):
             return Diff(1, -32, 0, 2)
     elif a == 207:
         if b == 143:
@@ -159,7 +157,7 @@ fn _to_lower(a: UInt8, b: UInt8, c: UInt8) -> Diff:
     if a == 225:
         if b == 130 and c >= 160 and c <= 191:
             return Diff(1, 50, -32, 3)
-        elif b == 131 and ((c >= 128 and c <= 132 and c & 1 == 0) or (c >= 129 and c <= 135 and c & 1 == 1) or (c == 141)):
+        elif b == 131 and ((c >= 128 and c <= 133) or (c == 135) or (c == 141)):
             return Diff(1, 49, 32, 3)
         elif b == 142:
             if c >= 160 and c <= 175:
@@ -171,7 +169,7 @@ fn _to_lower(a: UInt8, b: UInt8, c: UInt8) -> Diff:
                 return Diff(9, 31, 16, 3)
             elif c >= 176 and c <= 181:
                 return Diff(0, 0, 8, 3)
-        elif b == 178 and ((c >= 144 and c <= 186 and c & 1 == 0) or (c >= 145 and c <= 185 and c & 1 == 1) or (c == 189) or (c == 190) or (c == 191)):
+        elif b == 178 and ((c >= 144 and c <= 186) or (c >= 189 and c <= 191)):
             return Diff(0, -47, 0, 3)
         elif b == 184 and c >= 128 and c <= 190 and c & 1 == 0:
             return Diff(0, 0, 1, 3)
@@ -186,22 +184,16 @@ fn _to_lower(a: UInt8, b: UInt8, c: UInt8) -> Diff:
                 return Diff(0, 0, 1, 3)
         elif b == 187 and c >= 128 and c <= 190 and c & 1 == 0:
             return Diff(0, 0, 1, 3)
-        elif b == 188 and ((c >= 136 and c <= 142 and c & 1 == 0) or (c >= 137 and c <= 143 and c & 1 == 1) or (c >= 152 and c <= 156 and c & 1 == 0) or (c >= 153 and c <= 157 and c & 1 == 1) or (c >= 168 and c <= 174 and c & 1 == 0) or (c >= 169 and c <= 175 and c & 1 == 1) or (c >= 184 and c <= 190 and c & 1 == 0) or (c >= 185 and c <= 191 and c & 1 == 1)):
+        elif b == 188 and ((c >= 136 and c <= 143) or (c >= 152 and c <= 157) or (c >= 168 and c <= 175) or (c >= 184 and c <= 191)):
             return Diff(0, 0, -8, 3)
-        elif b == 189 and ((c >= 136 and c <= 140 and c & 1 == 0) or (c >= 137 and c <= 141 and c & 1 == 1) or (c >= 153 and c <= 159 and c & 1 == 1) or (c >= 168 and c <= 174 and c & 1 == 0) or (c >= 169 and c <= 175 and c & 1 == 1)):
+        elif b == 189 and ((c >= 136 and c <= 141) or (c >= 153 and c <= 159 and c & 1 == 1) or (c >= 168 and c <= 175)):
             return Diff(0, 0, -8, 3)
         elif b == 190:
-            if c >= 136 and c <= 142 and c & 1 == 0:
+            if c >= 136 and c <= 143:
                 return Diff(0, 0, -8, 3)
-            elif c >= 137 and c <= 143 and c & 1 == 1:
+            elif c >= 152 and c <= 159:
                 return Diff(0, 0, -8, 3)
-            elif c >= 152 and c <= 158 and c & 1 == 0:
-                return Diff(0, 0, -8, 3)
-            elif c >= 153 and c <= 159 and c & 1 == 1:
-                return Diff(0, 0, -8, 3)
-            elif c >= 168 and c <= 174 and c & 1 == 0:
-                return Diff(0, 0, -8, 3)
-            elif c >= 169 and c <= 175 and c & 1 == 1:
+            elif c >= 168 and c <= 175:
                 return Diff(0, 0, -8, 3)
             elif c == 184:
                 return Diff(0, 0, -8, 3)
@@ -396,9 +388,9 @@ fn _to_lower(a: UInt8, b: UInt8, c: UInt8, d: UInt8) -> Diff:
                 return Diff(0, 0, 1, -24)
             elif c == 147 and d >= 128 and d <= 147:
                 return Diff(0, 0, 0, 40)
-            elif c == 149 and ((d >= 176 and d <= 190 and d & 1 == 0) or (d >= 177 and d <= 185 and d & 1 == 1) or (d == 189) or (d == 191)):
+            elif c == 149 and ((d >= 176 and d <= 186) or (d >= 188 and d <= 191)):
                 return Diff(0, 0, 1, -25)
-            elif c == 150 and ((d >= 128 and d <= 148 and d & 1 == 0) or (d >= 129 and d <= 137 and d & 1 == 1) or (d >= 141 and d <= 145 and d & 1 == 1) or (d == 149)):
+            elif c == 150 and ((d >= 128 and d <= 138) or (d >= 140 and d <= 146) or (d == 148) or (d == 149)):
                 return Diff(0, 0, 0, 39)
             elif c == 178 and d >= 128 and d <= 178:
                 return Diff(0, 0, 1, 0)
@@ -443,27 +435,33 @@ fn lower_utf8(s: String) -> String:
         if char_length == 1:
             buf.append(Byte(b0 + _to_lower(b0)))
         elif char_length == 2:
-            var diff = _to_lower(b0, p[offset + 1])
+            var b1 = p[offset + 1]
+            var diff = _to_lower(b0, b1)
             var out_len = Int(diff[3])
             buf.append(Byte(Int(b0) + Int(diff[0])))
             if out_len >= 2:
-                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+                buf.append(Byte(Int(b1) + Int(diff[1])))
             if out_len >= 3:
                 buf.append(Byte(Int(diff[2])))
         elif char_length == 3:
-            var diff = _to_lower(b0, p[offset + 1], p[offset + 2])
+            var b1 = p[offset + 1]
+            var b2 = p[offset + 2]
+            var diff = _to_lower(b0, b1, b2)
             var out_len = Int(diff[3])
             buf.append(Byte(Int(b0) + Int(diff[0])))
             if out_len >= 2:
-                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+                buf.append(Byte(Int(b1) + Int(diff[1])))
             if out_len >= 3:
-                buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
+                buf.append(Byte(Int(b2) + Int(diff[2])))
         elif char_length == 4:
-            var diff = _to_lower(b0, p[offset + 1], p[offset + 2], p[offset + 3])
+            var b1 = p[offset + 1]
+            var b2 = p[offset + 2]
+            var b3 = p[offset + 3]
+            var diff = _to_lower(b0, b1, b2, b3)
             buf.append(Byte(Int(b0) + Int(diff[0])))
-            buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
-            buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
-            buf.append(Byte(Int(p[offset + 3]) + Int(diff[3])))
+            buf.append(Byte(Int(b1) + Int(diff[1])))
+            buf.append(Byte(Int(b2) + Int(diff[2])))
+            buf.append(Byte(Int(b3) + Int(diff[3])))
         offset += char_length
 
     return String(unsafe_from_utf8=buf)

--- a/to_lower_v2.mojo
+++ b/to_lower_v2.mojo
@@ -1,0 +1,470 @@
+from std.bit import count_leading_zeros
+
+
+comptime Diff = SIMD[DType.int32, 4]
+
+
+@always_inline
+fn _to_lower(a: UInt8) -> UInt8:
+    """Branch-free ASCII lowercase. Returns delta to add to the byte."""
+    var is_upper = (a >= 65) & (a <= 90)
+    return UInt8(Int(is_upper) * 32)
+
+
+@always_inline
+fn _to_lower(a: UInt8, b: UInt8) -> Diff:
+    """Given two bytes of a UTF-8 char, returns byte adjustments for lowercasing.
+    Returns Diff(delta_byte0, delta_byte1, extra_byte, output_len).
+    """
+    if a == 195:
+        if (b >= 128 and b <= 158 and b & 1 == 0) or (b >= 129 and b <= 149 and b & 1 == 1) or (b >= 153 and b <= 157 and b & 1 == 1):
+            return Diff(0, 32, 0, 2)
+    elif a == 196:
+        if (b >= 128 and b <= 174 and b & 1 == 0) or (b >= 178 and b <= 182 and b & 1 == 0) or (b >= 185 and b <= 189 and b & 1 == 1):
+            return Diff(0, 1, 0, 2)
+        elif b == 176:
+            return Diff(-91, -176, 0, 1)
+        elif b == 191:
+            return Diff(1, -63, 0, 2)
+    elif a == 197:
+        if (b >= 129 and b <= 135 and b & 1 == 1) or (b >= 138 and b <= 182 and b & 1 == 0) or (b >= 185 and b <= 189 and b & 1 == 1):
+            return Diff(0, 1, 0, 2)
+        elif b == 184:
+            return Diff(-2, 7, 0, 2)
+    elif a == 198:
+        if b == 129:
+            return Diff(3, 18, 0, 2)
+        elif (b == 130) or (b == 132) or (b == 135) or (b == 139) or (b == 145) or (b == 152) or (b >= 160 and b <= 164 and b & 1 == 0) or (b == 167) or (b == 172) or (b == 175) or (b == 179) or (b == 181) or (b == 184) or (b == 188):
+            return Diff(0, 1, 0, 2)
+        elif b == 134:
+            return Diff(3, 14, 0, 2)
+        elif (b == 137) or (b == 138) or (b == 147):
+            return Diff(3, 13, 0, 2)
+        elif b == 142:
+            return Diff(1, 15, 0, 2)
+        elif b == 143:
+            return Diff(3, 10, 0, 2)
+        elif b == 144:
+            return Diff(3, 11, 0, 2)
+        elif b == 148:
+            return Diff(3, 15, 0, 2)
+        elif (b == 150) or (b == 156):
+            return Diff(3, 19, 0, 2)
+        elif b == 151:
+            return Diff(3, 17, 0, 2)
+        elif b == 157:
+            return Diff(3, 21, 0, 2)
+        elif b == 159:
+            return Diff(3, 22, 0, 2)
+        elif (b == 166) or (b == 169) or (b == 174):
+            return Diff(4, -38, 0, 2)
+        elif (b == 177) or (b == 178):
+            return Diff(4, -39, 0, 2)
+        elif b == 183:
+            return Diff(4, -37, 0, 2)
+    elif a == 199:
+        if (b == 132) or (b == 135) or (b == 138) or (b == 177):
+            return Diff(0, 2, 0, 2)
+        elif (b == 133) or (b == 136) or (b >= 139 and b <= 155 and b & 1 == 1) or (b >= 158 and b <= 174 and b & 1 == 0) or (b == 178) or (b == 180) or (b >= 184 and b <= 190 and b & 1 == 0):
+            return Diff(0, 1, 0, 2)
+        elif b == 182:
+            return Diff(-1, -33, 0, 2)
+        elif b == 183:
+            return Diff(-1, 8, 0, 2)
+    elif a == 200:
+        if (b >= 128 and b <= 158 and b & 1 == 0) or (b >= 162 and b <= 178 and b & 1 == 0) or (b == 187):
+            return Diff(0, 1, 0, 2)
+        elif b == 160:
+            return Diff(-2, -2, 0, 2)
+        elif b == 186:
+            return Diff(26, -9, 165, 3)
+        elif b == 189:
+            return Diff(-2, -35, 0, 2)
+        elif b == 190:
+            return Diff(26, -13, 166, 3)
+    elif a == 201:
+        if (b == 129) or (b >= 134 and b <= 142 and b & 1 == 0):
+            return Diff(0, 1, 0, 2)
+        elif b == 131:
+            return Diff(-3, -3, 0, 2)
+        elif b == 132:
+            return Diff(1, 5, 0, 2)
+        elif b == 133:
+            return Diff(1, 7, 0, 2)
+    elif a == 205:
+        if (b == 176) or (b == 178) or (b == 182):
+            return Diff(0, 1, 0, 2)
+        elif b == 191:
+            return Diff(2, -12, 0, 2)
+    elif a == 206:
+        if b == 134:
+            return Diff(0, 38, 0, 2)
+        elif b >= 136 and b <= 138:
+            return Diff(0, 37, 0, 2)
+        elif b == 140:
+            return Diff(1, 0, 0, 2)
+        elif (b == 142) or (b == 143):
+            return Diff(1, -1, 0, 2)
+        elif b >= 145 and b <= 159:
+            return Diff(0, 32, 0, 2)
+        elif (b == 160) or (b >= 161 and b <= 171 and b & 1 == 1) or (b >= 164 and b <= 170 and b & 1 == 0):
+            return Diff(1, -32, 0, 2)
+    elif a == 207:
+        if b == 143:
+            return Diff(0, 8, 0, 2)
+        elif (b >= 152 and b <= 174 and b & 1 == 0) or (b == 183) or (b == 186):
+            return Diff(0, 1, 0, 2)
+        elif b == 180:
+            return Diff(-1, 4, 0, 2)
+        elif b == 185:
+            return Diff(0, -7, 0, 2)
+        elif b >= 189 and b <= 191:
+            return Diff(-2, -2, 0, 2)
+    elif a == 208:
+        if b >= 128 and b <= 143:
+            return Diff(1, 16, 0, 2)
+        elif b >= 144 and b <= 159:
+            return Diff(0, 32, 0, 2)
+        elif b >= 160 and b <= 175:
+            return Diff(1, -32, 0, 2)
+    elif a == 209:
+        if b >= 160 and b <= 190 and b & 1 == 0:
+            return Diff(0, 1, 0, 2)
+    elif a == 210:
+        if (b == 128) or (b >= 138 and b <= 190 and b & 1 == 0):
+            return Diff(0, 1, 0, 2)
+    elif a == 211:
+        if b == 128:
+            return Diff(0, 15, 0, 2)
+        elif (b >= 129 and b <= 141 and b & 1 == 1) or (b >= 144 and b <= 190 and b & 1 == 0):
+            return Diff(0, 1, 0, 2)
+    elif a == 212:
+        if b >= 128 and b <= 174 and b & 1 == 0:
+            return Diff(0, 1, 0, 2)
+        elif b >= 177 and b <= 191:
+            return Diff(1, -16, 0, 2)
+    elif a == 213:
+        if b >= 128 and b <= 143:
+            return Diff(0, 48, 0, 2)
+        elif b >= 144 and b <= 150:
+            return Diff(1, -16, 0, 2)
+    return Diff(0, 0, 0, 2)
+
+
+@always_inline
+fn _to_lower(a: UInt8, b: UInt8, c: UInt8) -> Diff:
+    """Given three bytes of a UTF-8 char, returns byte adjustments for lowercasing.
+    Returns Diff(delta_byte0, delta_byte1, delta_byte2, output_len).
+    """
+    if a == 225:
+        if b == 130 and c >= 160 and c <= 191:
+            return Diff(1, 50, -32, 3)
+        elif b == 131 and ((c >= 128 and c <= 132 and c & 1 == 0) or (c >= 129 and c <= 135 and c & 1 == 1) or (c == 141)):
+            return Diff(1, 49, 32, 3)
+        elif b == 142:
+            if c >= 160 and c <= 175:
+                return Diff(9, 31, 16, 3)
+            elif c >= 176 and c <= 191:
+                return Diff(9, 32, -48, 3)
+        elif b == 143:
+            if c >= 128 and c <= 175:
+                return Diff(9, 31, 16, 3)
+            elif c >= 176 and c <= 181:
+                return Diff(0, 0, 8, 3)
+        elif b == 178 and ((c >= 144 and c <= 186 and c & 1 == 0) or (c >= 145 and c <= 185 and c & 1 == 1) or (c == 189) or (c == 190) or (c == 191)):
+            return Diff(0, -47, 0, 3)
+        elif b == 184 and c >= 128 and c <= 190 and c & 1 == 0:
+            return Diff(0, 0, 1, 3)
+        elif b == 185 and c >= 128 and c <= 190 and c & 1 == 0:
+            return Diff(0, 0, 1, 3)
+        elif b == 186:
+            if c >= 128 and c <= 148 and c & 1 == 0:
+                return Diff(0, 0, 1, 3)
+            elif c == 158:
+                return Diff(-30, -27, -158, 2)
+            elif c >= 160 and c <= 190 and c & 1 == 0:
+                return Diff(0, 0, 1, 3)
+        elif b == 187 and c >= 128 and c <= 190 and c & 1 == 0:
+            return Diff(0, 0, 1, 3)
+        elif b == 188 and ((c >= 136 and c <= 142 and c & 1 == 0) or (c >= 137 and c <= 143 and c & 1 == 1) or (c >= 152 and c <= 156 and c & 1 == 0) or (c >= 153 and c <= 157 and c & 1 == 1) or (c >= 168 and c <= 174 and c & 1 == 0) or (c >= 169 and c <= 175 and c & 1 == 1) or (c >= 184 and c <= 190 and c & 1 == 0) or (c >= 185 and c <= 191 and c & 1 == 1)):
+            return Diff(0, 0, -8, 3)
+        elif b == 189 and ((c >= 136 and c <= 140 and c & 1 == 0) or (c >= 137 and c <= 141 and c & 1 == 1) or (c >= 153 and c <= 159 and c & 1 == 1) or (c >= 168 and c <= 174 and c & 1 == 0) or (c >= 169 and c <= 175 and c & 1 == 1)):
+            return Diff(0, 0, -8, 3)
+        elif b == 190:
+            if c >= 136 and c <= 142 and c & 1 == 0:
+                return Diff(0, 0, -8, 3)
+            elif c >= 137 and c <= 143 and c & 1 == 1:
+                return Diff(0, 0, -8, 3)
+            elif c >= 152 and c <= 158 and c & 1 == 0:
+                return Diff(0, 0, -8, 3)
+            elif c >= 153 and c <= 159 and c & 1 == 1:
+                return Diff(0, 0, -8, 3)
+            elif c >= 168 and c <= 174 and c & 1 == 0:
+                return Diff(0, 0, -8, 3)
+            elif c >= 169 and c <= 175 and c & 1 == 1:
+                return Diff(0, 0, -8, 3)
+            elif c == 184:
+                return Diff(0, 0, -8, 3)
+            elif c == 185:
+                return Diff(0, 0, -8, 3)
+            elif c == 186:
+                return Diff(0, -1, -10, 3)
+            elif c == 187:
+                return Diff(0, -1, -10, 3)
+            elif c == 188:
+                return Diff(0, 0, -9, 3)
+        elif b == 191:
+            if c >= 136 and c <= 139:
+                return Diff(0, -2, 42, 3)
+            elif c == 140:
+                return Diff(0, 0, -9, 3)
+            elif c == 152:
+                return Diff(0, 0, -8, 3)
+            elif c == 153:
+                return Diff(0, 0, -8, 3)
+            elif c == 154:
+                return Diff(0, -2, 28, 3)
+            elif c == 155:
+                return Diff(0, -2, 28, 3)
+            elif c == 168:
+                return Diff(0, 0, -8, 3)
+            elif c == 169:
+                return Diff(0, 0, -8, 3)
+            elif c == 170:
+                return Diff(0, -2, 16, 3)
+            elif c == 171:
+                return Diff(0, -2, 16, 3)
+            elif c == 172:
+                return Diff(0, 0, -7, 3)
+            elif c == 184:
+                return Diff(0, -2, 0, 3)
+            elif c == 185:
+                return Diff(0, -2, 0, 3)
+            elif c == 186:
+                return Diff(0, -2, 2, 3)
+            elif c == 187:
+                return Diff(0, -2, 2, 3)
+            elif c == 188:
+                return Diff(0, 0, -9, 3)
+    elif a == 226:
+        if b == 132:
+            if c == 166:
+                return Diff(-19, 5, -166, 2)
+            elif c == 170:
+                return Diff(-119, -132, -170, 1)
+            elif c == 171:
+                return Diff(-31, 33, -171, 2)
+            elif c == 178:
+                return Diff(0, 1, -36, 3)
+        elif b == 133 and c >= 160 and c <= 175:
+            return Diff(0, 0, 16, 3)
+        elif b == 134 and c == 131:
+            return Diff(0, 0, 1, 3)
+        elif b == 146 and c >= 182 and c <= 191:
+            return Diff(0, 1, -38, 3)
+        elif b == 147 and c >= 128 and c <= 143:
+            return Diff(0, 0, 26, 3)
+        elif b == 176:
+            if c >= 128 and c <= 143:
+                return Diff(0, 0, 48, 3)
+            elif c >= 144 and c <= 175:
+                return Diff(0, 1, -16, 3)
+        elif b == 177:
+            if c == 160:
+                return Diff(0, 0, 1, 3)
+            elif c == 162:
+                return Diff(-25, -6, -162, 2)
+            elif c == 163:
+                return Diff(-1, 4, 26, 3)
+            elif c == 164:
+                return Diff(-25, 12, -164, 2)
+            elif c >= 167 and c <= 171 and c & 1 == 1:
+                return Diff(0, 0, 1, 3)
+            elif c == 173:
+                return Diff(-25, -32, -173, 2)
+            elif c == 174:
+                return Diff(-25, 0, -174, 2)
+            elif c == 175:
+                return Diff(-25, -33, -175, 2)
+            elif c == 176:
+                return Diff(-25, -31, -176, 2)
+            elif c == 178:
+                return Diff(0, 0, 1, 3)
+            elif c == 181:
+                return Diff(0, 0, 1, 3)
+            elif c == 190:
+                return Diff(-26, 14, -190, 2)
+            elif c == 191:
+                return Diff(-25, -49, -191, 2)
+        elif b == 178 and c >= 128 and c <= 190 and c & 1 == 0:
+            return Diff(0, 0, 1, 3)
+        elif b == 179 and ((c >= 128 and c <= 162 and c & 1 == 0) or (c == 171) or (c == 173) or (c == 178)):
+            return Diff(0, 0, 1, 3)
+    elif a == 234:
+        if b == 153 and c >= 128 and c <= 172 and c & 1 == 0:
+            return Diff(0, 0, 1, 3)
+        elif b == 154 and c >= 128 and c <= 154 and c & 1 == 0:
+            return Diff(0, 0, 1, 3)
+        elif b == 156 and ((c >= 162 and c <= 174 and c & 1 == 0) or (c >= 178 and c <= 190 and c & 1 == 0)):
+            return Diff(0, 0, 1, 3)
+        elif b == 157:
+            if c >= 128 and c <= 174 and c & 1 == 0:
+                return Diff(0, 0, 1, 3)
+            elif c == 185:
+                return Diff(0, 0, 1, 3)
+            elif c == 187:
+                return Diff(0, 0, 1, 3)
+            elif c == 189:
+                return Diff(-9, 24, -4, 3)
+            elif c == 190:
+                return Diff(0, 0, 1, 3)
+        elif b == 158:
+            if c >= 128 and c <= 134 and c & 1 == 0:
+                return Diff(0, 0, 1, 3)
+            elif c == 139:
+                return Diff(0, 0, 1, 3)
+            elif c == 141:
+                return Diff(-33, 7, -141, 2)
+            elif c == 144:
+                return Diff(0, 0, 1, 3)
+            elif c == 146:
+                return Diff(0, 0, 1, 3)
+            elif c >= 150 and c <= 168 and c & 1 == 0:
+                return Diff(0, 0, 1, 3)
+            elif c == 170:
+                return Diff(-33, 8, -170, 2)
+            elif c == 171:
+                return Diff(-33, -2, -171, 2)
+            elif c == 172:
+                return Diff(-33, 3, -172, 2)
+            elif c == 173:
+                return Diff(-33, 14, -173, 2)
+            elif c == 174:
+                return Diff(-33, 12, -174, 2)
+            elif c == 176:
+                return Diff(-32, 0, -176, 2)
+            elif c == 177:
+                return Diff(-32, -23, -177, 2)
+            elif c == 178:
+                return Diff(-32, -1, -178, 2)
+            elif c == 179:
+                return Diff(0, 15, -32, 3)
+            elif c >= 180 and c <= 190 and c & 1 == 0:
+                return Diff(0, 0, 1, 3)
+        elif b == 159:
+            if c == 128:
+                return Diff(0, 0, 1, 3)
+            elif c == 130:
+                return Diff(0, 0, 1, 3)
+            elif c == 132:
+                return Diff(0, -1, 16, 3)
+            elif c == 133:
+                return Diff(-32, -29, -133, 2)
+            elif c == 134:
+                return Diff(-9, 23, 8, 3)
+            elif c == 135:
+                return Diff(0, 0, 1, 3)
+            elif c == 137:
+                return Diff(0, 0, 1, 3)
+            elif c == 144:
+                return Diff(0, 0, 1, 3)
+            elif c == 150:
+                return Diff(0, 0, 1, 3)
+            elif c == 152:
+                return Diff(0, 0, 1, 3)
+            elif c == 181:
+                return Diff(0, 0, 1, 3)
+    elif a == 239:
+        if b == 188 and c >= 161 and c <= 186:
+            return Diff(0, 1, -32, 3)
+    return Diff(0, 0, 0, 3)
+
+
+@always_inline
+fn _to_lower(a: UInt8, b: UInt8, c: UInt8, d: UInt8) -> Diff:
+    """Given four bytes of a UTF-8 char, returns byte adjustments for lowercasing.
+    Returns Diff(delta_byte0, delta_byte1, delta_byte2, delta_byte3).
+    """
+    if a == 240:
+        if b == 144:
+            if c == 144:
+                if d >= 128 and d <= 151:
+                    return Diff(0, 0, 0, 40)
+                elif d >= 152 and d <= 167:
+                    return Diff(0, 0, 1, -24)
+            elif c == 146 and d >= 176 and d <= 191:
+                return Diff(0, 0, 1, -24)
+            elif c == 147 and d >= 128 and d <= 147:
+                return Diff(0, 0, 0, 40)
+            elif c == 149 and ((d >= 176 and d <= 190 and d & 1 == 0) or (d >= 177 and d <= 185 and d & 1 == 1) or (d == 189) or (d == 191)):
+                return Diff(0, 0, 1, -25)
+            elif c == 150 and ((d >= 128 and d <= 148 and d & 1 == 0) or (d >= 129 and d <= 137 and d & 1 == 1) or (d >= 141 and d <= 145 and d & 1 == 1) or (d == 149)):
+                return Diff(0, 0, 0, 39)
+            elif c == 178 and d >= 128 and d <= 178:
+                return Diff(0, 0, 1, 0)
+        elif b == 145 and c == 162 and d >= 160 and d <= 191:
+            return Diff(0, 0, 1, -32)
+        elif b == 150 and c == 185 and d >= 128 and d <= 159:
+            return Diff(0, 0, 0, 32)
+        elif b == 158 and c == 164:
+            if d >= 128 and d <= 157:
+                return Diff(0, 0, 0, 34)
+            elif d >= 158 and d <= 161:
+                return Diff(0, 0, 1, -30)
+    return Diff(0, 0, 0, 0)
+
+
+fn lower_utf8(s: String) -> String:
+    """Convert a UTF-8 encoded string to lowercase using a decision tree.
+
+    Args:
+        s: Input string.
+
+    Returns:
+        A new string with all characters converted to lowercase.
+    """
+    var byte_len = s.byte_length()
+    var buf = List[Byte](capacity=byte_len // 2 * 3 + 1)
+    var offset = 0
+    var p = s.unsafe_ptr()
+    while offset < byte_len:
+        var b0 = p[offset]
+        # Detect UTF-8 character length from leading byte
+        var char_length: Int
+        if b0 >> 7 == 0:
+            char_length = 1
+        elif b0 >> 5 == 0b110:
+            char_length = 2
+        elif b0 >> 4 == 0b1110:
+            char_length = 3
+        else:
+            char_length = 4
+
+        if char_length == 1:
+            buf.append(Byte(b0 + _to_lower(b0)))
+        elif char_length == 2:
+            var diff = _to_lower(b0, p[offset + 1])
+            var out_len = Int(diff[3])
+            buf.append(Byte(Int(b0) + Int(diff[0])))
+            if out_len >= 2:
+                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+            if out_len >= 3:
+                buf.append(Byte(Int(diff[2])))
+        elif char_length == 3:
+            var diff = _to_lower(b0, p[offset + 1], p[offset + 2])
+            var out_len = Int(diff[3])
+            buf.append(Byte(Int(b0) + Int(diff[0])))
+            if out_len >= 2:
+                buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+            if out_len >= 3:
+                buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
+        elif char_length == 4:
+            var diff = _to_lower(b0, p[offset + 1], p[offset + 2], p[offset + 3])
+            buf.append(Byte(Int(b0) + Int(diff[0])))
+            buf.append(Byte(Int(p[offset + 1]) + Int(diff[1])))
+            buf.append(Byte(Int(p[offset + 2]) + Int(diff[2])))
+            buf.append(Byte(Int(p[offset + 3]) + Int(diff[3])))
+        offset += char_length
+
+    return String(unsafe_from_utf8=buf)
+


### PR DESCRIPTION
## Summary

- Adds `gen_to_lower_tree.py`: Python script that reads `to_lower.csv` and generates an optimized Mojo decision tree for UTF-8 lowercasing (no lookup tables, no memory overhead).
- Adds `to_lower_v2.mojo`: Generated output (468 lines vs 552 hand-written). Uses `SIMD[DType.int32, 4]` return type, compatible with Mojo nightly.
- Adds `test_to_lower_v2.mojo`: Test harness validating all 1,433 CSV mappings plus end-to-end string tests.

All 1,433 Unicode mappings from `to_lower.csv` pass. The generation is reproducible for future Unicode releases.

Related: https://github.com/modular/modular/issues/6177

Assisted-by: AI